### PR TITLE
Add Lwt support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ FINDLIB_NAME=osx-xattr
 MOD_NAME=osx_xattr
 
 OCAML_LIB_DIR=$(shell ocamlc -where)
-
+LWT_LIB_DIR=$(shell ocamlfind query lwt)
 CTYPES_LIB_DIR=$(shell ocamlfind query ctypes)
 
 OCAMLBUILD=CTYPES_LIB_DIR=$(CTYPES_LIB_DIR) OCAML_LIB_DIR=$(OCAML_LIB_DIR) \
+           LWT_LIB_DIR=$(LWT_LIB_DIR)       \
 	ocamlbuild -use-ocamlfind -classic-display
 
 WITH_LWT=$(shell ocamlfind query threads lwt > /dev/null 2>&1 ; echo $$?)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,9 @@ build:
 
 test: build
 	$(OCAMLBUILD) lib_test/test.native
+	$(OCAMLBUILD) lwt_test/test_lwt.native
 	./test.native
+	./test_lwt.native
 
 install:
 	ocamlfind install $(FINDLIB_NAME) META \

--- a/lib/osx_xattr_util.c
+++ b/lib/osx_xattr_util.c
@@ -2,7 +2,7 @@
 #include <caml/threads.h>
 #include <sys/xattr.h>
 
-ssize_t osx_xattr_get
+ssize_t osx_xattr_getxattr
 (const char *path, const char *name, void *value, size_t size,
  u_int32_t position, int options)
 {
@@ -13,7 +13,7 @@ ssize_t osx_xattr_get
   return r;
 }
 
-ssize_t osx_xattr_fget
+ssize_t osx_xattr_fgetxattr
 (int fd, const char *name, void *value, size_t size, u_int32_t position,
  int options)
 {
@@ -24,7 +24,7 @@ ssize_t osx_xattr_fget
   return r;
 }
 
-ssize_t osx_xattr_list
+ssize_t osx_xattr_listxattr
 (const char *path, char *namebuf, size_t size, int options)
 {
   ssize_t r;
@@ -34,7 +34,7 @@ ssize_t osx_xattr_list
   return r;
 }
 
-ssize_t osx_xattr_flist(int fd, char *namebuf, size_t size, int options)
+ssize_t osx_xattr_flistxattr(int fd, char *namebuf, size_t size, int options)
 {
   ssize_t r;
   caml_release_runtime_system();
@@ -43,7 +43,7 @@ ssize_t osx_xattr_flist(int fd, char *namebuf, size_t size, int options)
   return r;
 }
 
-int osx_xattr_set
+int osx_xattr_setxattr
 (const char *path, const char *name, void *value, size_t size,
  u_int32_t position, int options)
 {
@@ -54,7 +54,7 @@ int osx_xattr_set
   return r;
 }
 
-int osx_xattr_fset
+int osx_xattr_fsetxattr
 (int fd, const char *name, void *value, size_t size, u_int32_t position,
  int options)
 {
@@ -65,7 +65,7 @@ int osx_xattr_fset
   return r;
 }
 
-int osx_xattr_remove(const char *path, const char *name, int options)
+int osx_xattr_removexattr(const char *path, const char *name, int options)
 {
   int r;
   caml_release_runtime_system();
@@ -74,7 +74,7 @@ int osx_xattr_remove(const char *path, const char *name, int options)
   return r;
 }
 
-int osx_xattr_fremove(int fd, const char *name, int options)
+int osx_xattr_fremovexattr(int fd, const char *name, int options)
 {
   int r;
   caml_release_runtime_system();

--- a/lib/osx_xattr_util.h
+++ b/lib/osx_xattr_util.h
@@ -1,24 +1,24 @@
-ssize_t osx_xattr_get
+ssize_t osx_xattr_getxattr
 (const char *path, const char *name, void *value, size_t size,
  u_int32_t position, int options);
 
-ssize_t osx_xattr_fget
+ssize_t osx_xattr_fgetxattr
 (int fd, const char *name, void *value, size_t size, u_int32_t position,
  int options);
 
-ssize_t osx_xattr_list
+ssize_t osx_xattr_listxattr
 (const char *path, char *namebuf, size_t size, int options);
 
-ssize_t osx_xattr_flist(int fd, char *namebuf, size_t size, int options);
+ssize_t osx_xattr_flistxattr(int fd, char *namebuf, size_t size, int options);
 
-int osx_xattr_set
+int osx_xattr_setxattr
 (const char *path, const char *name, void *value, size_t size,
  u_int32_t position, int options);
 
-int osx_xattr_fset
+int osx_xattr_fsetxattr
 (int fd, const char *name, void *value, size_t size, u_int32_t position,
  int options);
 
-int osx_xattr_remove(const char *path, const char *name, int options);
+int osx_xattr_removexattr(const char *path, const char *name, int options);
 
-int osx_xattr_fremove(int fd, const char *name, int options);
+int osx_xattr_fremovexattr(int fd, const char *name, int options);

--- a/lib_gen/osx_xattr_bindgen.ml
+++ b/lib_gen/osx_xattr_bindgen.ml
@@ -15,11 +15,6 @@
  *
  *)
 
-let headers = "\
-#include <sys/xattr.h>\n\
-#include \"osx_xattr_util.h\"\n\
-"
-
 let prefix = "osx_xattr_"
 
 module Prefixed_bindings(F: Cstubs.FOREIGN) =
@@ -42,14 +37,16 @@ type configuration = {
 let standard_configuration = {
   errno = Cstubs.ignore_errno;
   concurrency = Cstubs.sequential;
-  headers;
+  headers = "#include <sys/xattr.h>\n\
+#include \"osx_xattr_util.h\"\n\
+";
   bindings = (module Prefixed_bindings)
 }
 
 let lwt_configuration = {
   errno = Cstubs.return_errno;
   concurrency = Cstubs.lwt_jobs;
-  headers;
+  headers = "#include <sys/xattr.h>\n";
   bindings = (module Osx_xattr_bindings.C)
 }
 

--- a/lib_gen/osx_xattr_bindgen.ml
+++ b/lib_gen/osx_xattr_bindgen.ml
@@ -15,18 +15,68 @@
  *
  *)
 
-open Ctypes
+let headers = "\
+#include <sys/xattr.h>\n\
+#include \"osx_xattr_util.h\"\n\
+"
+
+let prefix = "osx_xattr_"
+
+module Prefixed_bindings(F: Cstubs.FOREIGN) =
+struct
+  include Osx_xattr_bindings.C(
+    struct
+      include F
+      let foreign f = F.foreign (prefix ^ f)
+    end
+    )
+end
+
+type configuration = {
+  errno: Cstubs.errno_policy;
+  concurrency: Cstubs.concurrency_policy;
+  headers: string;
+  bindings: (module Cstubs.BINDINGS)
+}
+
+let standard_configuration = {
+  errno = Cstubs.ignore_errno;
+  concurrency = Cstubs.sequential;
+  headers;
+  bindings = (module Prefixed_bindings)
+}
+
+let lwt_configuration = {
+  errno = Cstubs.return_errno;
+  concurrency = Cstubs.lwt_jobs;
+  headers;
+  bindings = (module Osx_xattr_bindings.C)
+}
+
+let configuration = ref standard_configuration
+let ml_file = ref ""
+let c_file = ref ""
+
+let argspec : (Arg.key * Arg.spec * Arg.doc) list = [
+  "--ml-file", Arg.Set_string ml_file, "set the ML output file";
+  "--c-file", Arg.Set_string c_file, "set the C output file";
+  "--lwt-bindings", Arg.Unit (fun () -> configuration := lwt_configuration),
+  "generate Lwt jobs bindings";
+]
 
 let () =
+  let () = Arg.parse argspec failwith "" in
+  if !ml_file = "" || !c_file = "" then
+    failwith "Both --ml-file and --c-file arguments must be supplied";
+  let {errno; concurrency; headers; bindings} = !configuration in
   let prefix = "caml_" in
-  let stubs_oc = open_out "lib/osx_xattr_stubs.c" in
+  let stubs_oc = open_out !c_file in
   let fmt = Format.formatter_of_out_channel stubs_oc in
-  Format.fprintf fmt "#include <sys/xattr.h>@.";
-  Format.fprintf fmt "#include \"osx_xattr_util.h\"@.";
-  Cstubs.write_c fmt ~prefix (module Osx_xattr_bindings.C);
+  Format.fprintf fmt "%s@." headers;
+  Cstubs.write_c ~errno ~concurrency fmt ~prefix bindings;
   close_out stubs_oc;
 
-  let generated_oc = open_out "lib/osx_xattr_generated.ml" in
+  let generated_oc = open_out !ml_file in
   let fmt = Format.formatter_of_out_channel generated_oc in
-  Cstubs.write_ml fmt ~prefix (module Osx_xattr_bindings.C);
+  Cstubs.write_ml ~errno ~concurrency fmt ~prefix bindings;
   close_out generated_oc

--- a/lib_gen/osx_xattr_bindings.ml
+++ b/lib_gen/osx_xattr_bindings.ml
@@ -109,12 +109,12 @@ module C(F: Cstubs.FOREIGN) = struct
   ))
 
   let set = F.(foreign "setxattr" (
-    string @-> string @-> ocaml_string @-> size_t @-> uint32_t @->
+    string @-> string @-> string @-> size_t @-> uint32_t @->
     SetOptions.t @-> returning int
   ))
 
   let fset = F.(foreign "fsetxattr" (
-    int @-> string @-> ocaml_string @-> size_t @-> uint32_t @->
+    int @-> string @-> string @-> size_t @-> uint32_t @->
     SetOptions.t @-> returning int
   ))
 

--- a/lib_gen/osx_xattr_bindings.ml
+++ b/lib_gen/osx_xattr_bindings.ml
@@ -88,41 +88,41 @@ module C(F: Cstubs.FOREIGN) = struct
 
   end
 
-  let get = F.(foreign "osx_xattr_get" (
+  let get = F.(foreign "getxattr" (
     string @-> string @-> ptr void @-> size_t @-> uint32_t @->
     GetOptions.t @-> returning PosixTypes.ssize_t
   ))
 
-  let fget = F.(foreign "osx_xattr_fget" (
+  let fget = F.(foreign "fgetxattr" (
     int @-> string @-> ptr void @-> size_t @-> uint32_t @->
     GetOptions.t @-> returning PosixTypes.ssize_t
   ))
 
-  let list = F.(foreign "osx_xattr_list" (
+  let list = F.(foreign "listxattr" (
     string @-> ptr void @-> size_t @-> GetOptions.t @->
     returning PosixTypes.ssize_t
   ))
 
-  let flist = F.(foreign "osx_xattr_flist" (
+  let flist = F.(foreign "flistxattr" (
     int @-> ptr void @-> size_t @-> GetOptions.t @->
     returning PosixTypes.ssize_t
   ))
 
-  let set = F.(foreign "osx_xattr_set" (
+  let set = F.(foreign "setxattr" (
     string @-> string @-> ocaml_string @-> size_t @-> uint32_t @->
     SetOptions.t @-> returning int
   ))
 
-  let fset = F.(foreign "osx_xattr_fset" (
+  let fset = F.(foreign "fsetxattr" (
     int @-> string @-> ocaml_string @-> size_t @-> uint32_t @->
     SetOptions.t @-> returning int
   ))
 
-  let remove = F.(foreign "osx_xattr_remove" (
+  let remove = F.(foreign "removexattr" (
     string @-> string @-> GetOptions.t @-> returning int
   ))
 
-  let fremove = F.(foreign "osx_xattr_fremove" (
+  let fremove = F.(foreign "fremovexattr" (
     int @-> string @-> GetOptions.t @-> returning int
   ))
 end

--- a/lwt/_tags
+++ b/lwt/_tags
@@ -1,1 +1,4 @@
-<*.*>: package(lwt)
+<*.*>: package(lwt.unix), thread, package(ctypes.stubs)
+<*.*>: package(unix-type-representations), package(unix-errno)
+<osx_xattr_lwt_stubs.c>: use_lwt, use_ctypes
+<*.{cma,cmxa}>: use_osx_xattr_lwt_stubs

--- a/lwt/libosx_xattr_lwt_stubs.clib
+++ b/lwt/libosx_xattr_lwt_stubs.clib
@@ -1,0 +1,1 @@
+osx_xattr_lwt_stubs.o

--- a/lwt/osx_xattr_lwt.ml
+++ b/lwt/osx_xattr_lwt.ml
@@ -169,3 +169,13 @@ let set ?(no_follow=false) ?(create=false) ?(replace=false) path name value =
       raise (Errno.Error {Errno.errno = errno_of_code errno; call = "setxattr";
                           label = name; })
     else Lwt.return_unit
+
+let fset ?(create=false) ?(replace=false) fd name value =
+  let size = Unsigned.Size_t.of_int (String.length value) in
+  let fd = int_of_fd fd in
+  (C.fset fd name value size Unsigned.UInt32.zero
+     { C.SetOptions.no_follow=false; create; replace }).Generated.lwt >>= fun (rc, errno) ->
+    if rc < 0 then
+      raise (Errno.Error {Errno.errno = errno_of_code errno; call = "fsetxattr";
+                          label = name; })
+    else Lwt.return_unit

--- a/lwt/osx_xattr_lwt.ml
+++ b/lwt/osx_xattr_lwt.ml
@@ -186,3 +186,12 @@ let remove ?(no_follow=false) ?(show_compression=false) path name =
       raise (Errno.Error {Errno.errno = errno_of_code errno; call = "removexattr";
                           label = name; })
   else Lwt.return_unit
+
+let fremove ?(show_compression=false) fd name =
+  let fd = int_of_fd fd in
+  (C.fremove fd name
+     { C.GetOptions.no_follow=false; show_compression }).Generated.lwt >>= fun (rc, errno) ->
+  if rc < 0 then
+      raise (Errno.Error {Errno.errno = errno_of_code errno; call = "fremovexattr";
+                          label = name; })
+  else Lwt.return_unit

--- a/lwt/osx_xattr_lwt.ml
+++ b/lwt/osx_xattr_lwt.ml
@@ -179,3 +179,10 @@ let fset ?(create=false) ?(replace=false) fd name value =
       raise (Errno.Error {Errno.errno = errno_of_code errno; call = "fsetxattr";
                           label = name; })
     else Lwt.return_unit
+
+let remove ?(no_follow=false) ?(show_compression=false) path name =
+  (C.remove path name { C.GetOptions.no_follow; show_compression }).Generated.lwt >>= fun (rc, errno) ->
+  if rc < 0 then
+      raise (Errno.Error {Errno.errno = errno_of_code errno; call = "removexattr";
+                          label = name; })
+  else Lwt.return_unit

--- a/lwt/osx_xattr_lwt.ml
+++ b/lwt/osx_xattr_lwt.ml
@@ -26,6 +26,13 @@ open Lwt.Infix
 let int_of_fd = Unix_representations.int_of_file_descr
 let errno_of_code code = Errno.of_code ~host:Errno_unix.host code
 
+let handle_errno ~call ~label errno return =
+  let errnos = errno_of_code errno in
+  if List.mem Errno.ENOATTR errnos then Lwt.return return
+  else raise (Errno.Error {
+      Errno.errno = errnos; call; label;
+    })
+  
 let get_size ?(no_follow=false) ?(show_compression=false) path name =
   let call =
     C.get path name null (Unsigned.Size_t.of_int 0)
@@ -33,9 +40,26 @@ let get_size ?(no_follow=false) ?(show_compression=false) path name =
   in
   call.Generated.lwt >>= fun (size, errno) ->
   let size = Int64.to_int (PosixTypes.Ssize.to_int64 size) in
-  if size >= 0 then Lwt.return_some size else
-    let errnos = errno_of_code errno in
-    if List.mem Errno.ENOATTR errnos then Lwt.return_none
-    else raise (Errno.Error {
-        Errno.errno = errnos; call = "getxattr"; label = name;
-      })
+  if size >= 0 then Lwt.return_some size
+  else handle_errno ~call:"getxattr" ~label:name errno None
+
+let get ?(no_follow=false) ?(show_compression=false) ?(size=64) path name =
+  let rec call count =
+    let buf = allocate_n char ~count in
+    (C.get path name (to_voidp buf) (Unsigned.Size_t.of_int count)
+       Unsigned.UInt32.zero
+       { C.GetOptions.no_follow; show_compression }).Generated.lwt >>= fun (read, errno) ->
+    let read = Int64.to_int (PosixTypes.Ssize.to_int64 read) in
+    if read < 0 then
+      let errnos = errno_of_code errno in
+      if List.mem Errno.ERANGE errnos
+      then get_size ~no_follow ~show_compression path name >>= function
+        | Some size -> call size
+        | None -> Lwt.return_none
+      else if List.mem Errno.ENOATTR errnos then Lwt.return_none
+      else raise (Errno.Error {
+      Errno.errno = errnos; call = "getxattr"; label = name;
+        })
+    else Lwt.return_some (string_from_ptr buf ~length:read)
+  in
+  call size

--- a/lwt/osx_xattr_lwt.ml
+++ b/lwt/osx_xattr_lwt.ml
@@ -130,3 +130,13 @@ let list ?(no_follow=false) ?(show_compression=false) ?(size=64) path =
     else Lwt.return (list_of_strings_buffer [] buf read)
   in
   call size
+
+let flist_size ?(show_compression=false) fd =
+  let fd = int_of_fd fd in
+  let label = string_of_int fd in
+  (C.flist fd null (Unsigned.Size_t.of_int 0)
+     { C.GetOptions.no_follow=false; show_compression }).Generated.lwt >>= fun (size, errno) ->
+  let size = Int64.to_int (PosixTypes.Ssize.to_int64 size) in  
+  if size < 0
+  then raise (Errno.Error {Errno.errno = errno_of_code errno; call = "flistxattr"; label; })
+  else Lwt.return size

--- a/lwt/osx_xattr_lwt.ml
+++ b/lwt/osx_xattr_lwt.ml
@@ -160,3 +160,12 @@ let flist ?(show_compression=false) ?(size=64) fd =
     else Lwt.return (list_of_strings_buffer [] buf read)
   in
   call size
+
+let set ?(no_follow=false) ?(create=false) ?(replace=false) path name value =
+  let size = Unsigned.Size_t.of_int (String.length value) in
+  (C.set path name value size Unsigned.UInt32.zero
+     { C.SetOptions.no_follow; create; replace }).Generated.lwt >>= fun (rc, errno) ->
+    if rc < 0 then
+      raise (Errno.Error {Errno.errno = errno_of_code errno; call = "setxattr";
+                          label = name; })
+    else Lwt.return_unit

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -17,3 +17,7 @@
 
 val get_size :
   ?no_follow:bool -> ?show_compression:bool -> string -> string -> int option Lwt.t
+
+val get :
+  ?no_follow:bool -> ?show_compression:bool -> ?size:int ->
+  string -> string -> string option Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -41,3 +41,7 @@ val flist_size : ?show_compression:bool -> Unix.file_descr -> int Lwt.t
 
 val flist :
   ?show_compression:bool -> ?size:int -> Unix.file_descr -> string list Lwt.t
+
+val set :
+  ?no_follow:bool -> ?create:bool -> ?replace:bool ->
+  string -> string -> string -> unit Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -32,3 +32,7 @@ val fget :
 val list_size :
   ?no_follow:bool -> ?show_compression:bool ->
   string -> int Lwt.t
+
+val list :
+  ?no_follow:bool -> ?show_compression:bool -> ?size:int ->
+  string -> string list Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -28,3 +28,7 @@ val fget_size :
 val fget :
   ?show_compression:bool -> ?size:int ->
   Unix.file_descr -> string -> string option Lwt.t
+
+val list_size :
+  ?no_follow:bool -> ?show_compression:bool ->
+  string -> int Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -52,3 +52,5 @@ val fset :
 val remove :
   ?no_follow:bool -> ?show_compression:bool ->
   string -> string -> unit Lwt.t
+
+val fremove : ?show_compression:bool -> Unix.file_descr -> string -> unit Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -38,3 +38,6 @@ val list :
   string -> string list Lwt.t
 
 val flist_size : ?show_compression:bool -> Unix.file_descr -> int Lwt.t
+
+val flist :
+  ?show_compression:bool -> ?size:int -> Unix.file_descr -> string list Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -36,3 +36,5 @@ val list_size :
 val list :
   ?no_follow:bool -> ?show_compression:bool -> ?size:int ->
   string -> string list Lwt.t
+
+val flist_size : ?show_compression:bool -> Unix.file_descr -> int Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -14,3 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  *)
+
+val get_size :
+  ?no_follow:bool -> ?show_compression:bool -> string -> string -> int option Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -24,3 +24,7 @@ val get :
 
 val fget_size :
   ?show_compression:bool -> Unix.file_descr -> string -> int option Lwt.t
+
+val fget :
+  ?show_compression:bool -> ?size:int ->
+  Unix.file_descr -> string -> string option Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -21,3 +21,6 @@ val get_size :
 val get :
   ?no_follow:bool -> ?show_compression:bool -> ?size:int ->
   string -> string -> string option Lwt.t
+
+val fget_size :
+  ?show_compression:bool -> Unix.file_descr -> string -> int option Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -48,3 +48,7 @@ val set :
 
 val fset :
   ?create:bool -> ?replace:bool -> Unix.file_descr -> string -> string -> unit Lwt.t
+
+val remove :
+  ?no_follow:bool -> ?show_compression:bool ->
+  string -> string -> unit Lwt.t

--- a/lwt/osx_xattr_lwt.mli
+++ b/lwt/osx_xattr_lwt.mli
@@ -45,3 +45,6 @@ val flist :
 val set :
   ?no_follow:bool -> ?create:bool -> ?replace:bool ->
   string -> string -> string -> unit Lwt.t
+
+val fset :
+  ?create:bool -> ?replace:bool -> Unix.file_descr -> string -> string -> unit Lwt.t

--- a/lwt/osx_xattr_lwt.mllib
+++ b/lwt/osx_xattr_lwt.mllib
@@ -1,0 +1,2 @@
+Osx_xattr_lwt
+Osx_xattr_lwt_generated

--- a/lwt_test/_tags
+++ b/lwt_test/_tags
@@ -1,0 +1,3 @@
+<*.*>: package(alcotest), package(ctypes.stubs), package(lwt.unix)
+<*.*>: use_osx_xattr_lwt_stubs
+<*.*>: package(unix-errno.unix), package(unix-type-representations)

--- a/lwt_test/test_lwt.ml
+++ b/lwt_test/test_lwt.ml
@@ -1,0 +1,103 @@
+(*
+ * Copyright (c) 2016 David Sheets <dsheets@docker.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open Lwt.Infix
+
+module Basic = struct
+  let test_file = "__test_xattr"
+  
+  let state = ref None
+
+  let setup () = match !state with
+    | Some fd -> fd
+    | None ->
+      (try Unix.unlink test_file
+       with Unix.Unix_error (Unix.ENOENT, "unlink", _) -> ());
+      let fd = Unix.(openfile test_file [O_CREAT] 0o600) in
+      state := Some fd;
+      fd
+
+  let cleanup () =
+    Unix.unlink test_file
+
+  let set_get () =
+    let _fd = setup () in
+    Lwt_main.run (
+      let attr = "set_get" in
+      let value = "set_get value" in
+      Osx_xattr_lwt.set test_file attr value >>= fun () ->
+      Osx_xattr_lwt.get test_file attr >>= function
+      | Some value' -> Lwt.return (Alcotest.(check string) "set_get" value value')
+      | None -> Alcotest.fail "couldn't get xattr"
+    )
+
+  let fset_fget () =
+    let fd = setup () in
+    Lwt_main.run (
+      let attr = "fset_fget" in
+      let value = "fset_fget value" in
+      Osx_xattr_lwt.fset fd attr value >>= fun () ->
+      Osx_xattr_lwt.fget fd attr >>= function
+      | Some value' -> Lwt.return (Alcotest.(check string) "fset_fget" value value')
+      | None -> Alcotest.fail "couldn't get xattr"
+    )
+
+  let list_remove () =
+    let _fd = setup () in
+    Lwt_main.run (
+      (* TODO: make this test stand-alone *)
+      Osx_xattr_lwt.list test_file >>= fun xattrs ->
+      Alcotest.(check (list string)) "list_remove before"
+        (List.sort String.compare ["set_get"; "fset_fget"])
+        (List.sort String.compare xattrs);
+      Osx_xattr_lwt.remove test_file "set_get" >>= fun () ->
+      Osx_xattr_lwt.list test_file >>= fun xattrs ->
+      Alcotest.(check (list string)) "list_remove after" ["fset_fget"] xattrs;
+      Lwt.return_unit
+    )
+
+  let flist_fremove () =
+    let fd = setup () in
+    Lwt_main.run (
+      (* TODO: make this test stand-alone *)
+      Osx_xattr_lwt.flist fd >>= fun xattrs ->
+      Alcotest.(check (list string)) "flist_fremove before" ["fset_fget"] xattrs;
+      Osx_xattr_lwt.fremove fd "fset_fget" >>= fun () ->
+      Osx_xattr_lwt.flist fd >>= fun xattrs ->
+      Alcotest.(check (list string)) "flist_fremove after" [] xattrs;
+      (* TODO: This should happen after all tests *)
+      cleanup ();
+      Lwt.return_unit
+    )
+
+  let tests = [
+    "set_get",       `Quick, set_get;
+    "fset_fget",     `Quick, fset_fget;
+    "list_remove",   `Quick, list_remove;
+    "flist_fremove", `Quick, flist_fremove;
+  ]
+end
+
+let tests = [
+  "Basic", Basic.tests;
+]
+
+let cleanup () =
+  Basic.cleanup ()
+
+;;
+Alcotest.run "OSX xattr" tests

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -42,7 +42,11 @@ dispatch begin
       ~prods:["lib/%_stubs.c"; "lib/%_generated.ml"]
       ~deps: ["lib_gen/%_bindgen.byte"]
       (fun env build ->
-        Cmd (A(env "lib_gen/%_bindgen.byte")));
+        Cmd (S[A(env "lib_gen/%_bindgen.byte");
+               A"--c-file";
+               A(env "lib/%_stubs.c");
+                 A"--ml-file";
+               A(env "lib/%_generated.ml")]));
 
     copy_rule "cstubs: lib_gen/x_bindings.ml -> lib/x_bindings.ml"
       "lib_gen/%_bindings.ml" "lib/%_bindings.ml";

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -2,6 +2,7 @@ open Ocamlbuild_plugin;;
 open Ocamlbuild_pack;;
 
 let ctypes_libdir = Sys.getenv "CTYPES_LIB_DIR" in
+let lwt_libdir = Sys.getenv "LWT_LIB_DIR" in
 let ocaml_libdir = Sys.getenv "OCAML_LIB_DIR" in
 
 dispatch begin
@@ -48,6 +49,17 @@ dispatch begin
                  A"--ml-file";
                A(env "lib/%_generated.ml")]));
 
+    rule "cstubs: lwt/x_bindings.ml -> x_stubs.c, x_generated.ml"
+      ~prods:["lwt/%_lwt_stubs.c"; "lwt/%_lwt_generated.ml"]
+      ~deps: ["lib_gen/%_bindgen.byte"]
+      (fun env build ->
+        Cmd (S[A(env "lib_gen/%_bindgen.byte");
+               A"--lwt-bindings";
+               A"--c-file";
+               A(env "lwt/%_lwt_stubs.c");
+                 A"--ml-file";
+               A(env "lwt/%_lwt_generated.ml")]));
+
     copy_rule "cstubs: lib_gen/x_bindings.ml -> lib/x_bindings.ml"
       "lib_gen/%_bindings.ml" "lib/%_bindings.ml";
 
@@ -55,12 +67,14 @@ dispatch begin
     flag ["c"; "ocamlmklib"] & S[A"-L/usr/local/lib"];
     flag ["ocaml"; "link"; "native"; "program"] &
       S[A"-cclib"; A"-L/usr/local/lib";
-        A"-cclib"; A("-L"^Unix.getcwd()^"/_build/lib")];
+        A"-cclib"; A("-L"^Unix.getcwd()^"/_build/lib");
+        A"-cclib"; A("-L"^Unix.getcwd()^"/_build/lwt")];
 
     (* Linking cstubs *)
     dep ["c"; "compile"; "use_osx_xattr_util"]
       ["lib/osx_xattr_util.o"; "lib/osx_xattr_util.h"];
     flag ["c"; "compile"; "use_ctypes"] & S[A"-I"; A ctypes_libdir];
+    flag ["c"; "compile"; "use_lwt"] & S[A"-I"; A lwt_libdir];
     flag ["c"; "compile"; "debug"] & A"-g";
 
     (* Linking generated stubs *)
@@ -74,6 +88,17 @@ dispatch begin
     flag ["ocaml"; "link"; "native"; "library"; "use_osx_xattr_stubs"] &
     S[A"-cclib"; A"-losx_xattr_stubs"];
 
+    (* Linking generated lwt stubs *)
+    dep ["ocaml"; "link"; "byte"; "library"; "use_osx_xattr_lwt_stubs"]
+      ["lwt/dllosx_xattr_lwt_stubs"-.-(!Options.ext_dll)];
+    flag ["ocaml"; "link"; "byte"; "library"; "use_osx_xattr_lwt_stubs"] &
+    S[A"-dllib"; A"-losx_xattr_lwt_stubs"];
+
+    dep ["ocaml"; "link"; "native"; "library"; "use_osx_xattr_lwt_stubs"]
+      ["lwt/libosx_xattr_lwt_stubs"-.-(!Options.ext_lib)];
+    flag ["ocaml"; "link"; "native"; "library"; "use_osx_xattr_lwt_stubs"] &
+    S[A"-cclib"; A"-losx_xattr_lwt_stubs"];
+
     (* Linking tests *)
     flag ["ocaml"; "link"; "byte"; "program"; "use_osx_xattr_stubs"] &
       S[A"-dllib"; A"-losx_xattr_stubs"];
@@ -84,6 +109,18 @@ dispatch begin
       S[A"-cclib"; A"-losx_xattr_stubs"];
     dep ["ocaml"; "link"; "native"; "program"; "use_osx_xattr_stubs"]
       ["lib/libosx_xattr_stubs"-.-(!Options.ext_lib)];
+
+    (* Linking Lwt tests *)
+    flag ["ocaml"; "link"; "byte"; "program"; "use_osx_xattr_lwt_stubs"] &
+      S[A"-dllib"; A"-losx_xattr_lwt_stubs"];
+    dep ["ocaml"; "link"; "byte"; "program"; "use_osx_xattr_lwt_stubs"]
+      ["lwt/dllosx_xattr_lwt_stubs"-.-(!Options.ext_dll)];
+
+    flag ["ocaml"; "link"; "native"; "program"; "use_osx_xattr_lwt_stubs"] &
+      S[A"-cclib"; A"-losx_xattr_lwt_stubs"];
+    dep ["ocaml"; "link"; "native"; "program"; "use_osx_xattr_lwt_stubs"]
+      ["lwt/libosx_xattr_lwt_stubs"-.-(!Options.ext_lib)];
+
 
   | _ -> ()
 end;;

--- a/opam
+++ b/opam
@@ -22,7 +22,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "alcotest" {test}
-  "ctypes" {>= "0.4.0"}
+  "ctypes" {>= "0.6.2"}
   "unix-errno" {>= "0.4.0"}
   "base-unix"
   "unix-type-representations"


### PR DESCRIPTION
This pull request adds a module `Osx_xattr_lwt` that mirrors the existing [`Osx_xattr`](https://github.com/dsheets/ocaml-osx-xattr/blob/master/lib/osx_xattr.mli) module except that each function is implemented as an [Lwt job](https://ocsigen.org/lwt/2.5.1/api/Lwt_unix#TYPEjob).

The implementation is only lightly tested, but mirrors the structure of the existing code quite closely.  There is an Lwt version of the existing test suite.

The ctypes dependency is constrained to a currently-unreleased version (0.6.2) because the code in this PR relies on some [pending support for Lwt functions with unusual numbers of arguments](https://github.com/ocamllabs/ocaml-ctypes/pull/400).
